### PR TITLE
Fix tiling overlap bug

### DIFF
--- a/hawk_eye/data_generation/slice_image.py
+++ b/hawk_eye/data_generation/slice_image.py
@@ -32,13 +32,13 @@ def slice_image(
         width, height = image.size
 
         # Cropping logic repurposed from hawk_eye.inference.find_targets.tile_image()
-        for x in range(0, width, tile_size[0] - overlap):
+        for x in range(0, width - overlap, tile_size[0] - overlap):
 
             # Shift back to extract tiles on the image
             if x + tile_size[0] >= width and x != 0:
                 x = width - tile_size[0]
 
-            for y in range(0, height, tile_size[1] - overlap):
+            for y in range(0, height - overlap, tile_size[1] - overlap):
 
                 if y + tile_size[1] >= height and y != 0:
                     y = height - tile_size[1]

--- a/hawk_eye/inference/find_targets.py
+++ b/hawk_eye/inference/find_targets.py
@@ -214,7 +214,7 @@ def find_targets(
     image: Image.Image,
     clf_model: torch.nn.Module,
     det_model: torch.nn.Module,
-    clf_confidence: float = 0.9,
+    clf_confidence: float = 0.0,
 ) -> None:
     """ Tile up image, classify them, then perform object detection where it's needed.
 

--- a/hawk_eye/inference/find_targets.py
+++ b/hawk_eye/inference/find_targets.py
@@ -214,7 +214,7 @@ def find_targets(
     image: Image.Image,
     clf_model: torch.nn.Module,
     det_model: torch.nn.Module,
-    clf_confidence: float = 0.0,
+    clf_confidence: float = 0.9,
 ) -> None:
     """ Tile up image, classify them, then perform object detection where it's needed.
 

--- a/hawk_eye/inference/find_targets.py
+++ b/hawk_eye/inference/find_targets.py
@@ -86,12 +86,12 @@ def tile_image(
     x_step = width if width == tile_size[0] else tile_size[0] - overlap
     y_step = height if height == tile_size[1] else tile_size[1] - overlap
 
-    for x in range(0, width, x_step):
+    for x in range(0, width - overlap, x_step):
         # Shift back to extract tiles on the image
         if x + tile_size[0] >= width and x != 0:
             x = width - tile_size[0]
 
-        for y in range(0, height, y_step):
+        for y in range(0, height - overlap, y_step):
             if y + tile_size[1] >= height and y != 0:
                 y = height - tile_size[1]
 


### PR DESCRIPTION
This PR brings in a fix to the tiling bug in `slice_image.py` and `find_targets.py`. Without this fix, the tiles along the right edge of the image were inferenced twice. 